### PR TITLE
Configure docker-compose for static nginx + nginx-proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,10 @@ proxy:
      - "80:80"
   volumes:
      - /var/run/docker.sock:/tmp/docker.sock:ro
+  environment:
+     DEFAULT_HOST: www.mysite.com
 
 frontend:
   build: frontend/
-  ports:
-     - "8000"
-  volumes:
-     - frontend/:/data/www
   environment:
      VIRTUAL_HOST: www.mysite.com
-     VIRTUAL_PORT: 8000


### PR DESCRIPTION
Set a default host so nginx always handles the request. curl boot2dockerip should now respond, even without setting a HOST.  Alternatively, use curl -H "Host: www.mysite.com"

Nginx is running on PORT 80, no need to change / expose alternative ports, Docker can handle this.

No need to change the volumes, the static website is inside the image when it was built. To update the site, rebuild the image.
